### PR TITLE
Add language size to statistics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.17', '1.18', '1.19']
+        go: ['1.20', '1.21', '1.22']
     steps:
       - uses: actions/checkout@v4
       - name: Build with Go ${{ matrix.go }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.17', '1.18', '1.19']
+        go: ['1.20', '1.21', '1.22']
     steps:
       - uses: actions/checkout@v4
       - name: Lint in Go ${{ matrix.go }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.17', '1.18', '1.19']
+        go: ['1.20', '1.21', '1.22']
     steps:
       - uses: actions/checkout@v4
       - name: Test in Go ${{ matrix.go }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stscoundrel/polylinguist
 
-go 1.19
+go 1.20
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/stats/service.go
+++ b/stats/service.go
@@ -8,6 +8,7 @@ import (
 
 type LanguageStatistic struct {
 	Name       string
+	Size       int
 	Percentage float64
 	Color      string
 }
@@ -89,6 +90,7 @@ func getLanguagesStats(sizeMapping map[string]int, colorMapping map[string]strin
 	for language, size := range sizeMapping {
 		stats = append(stats, LanguageStatistic{
 			Name:       language,
+			Size:       size,
 			Percentage: (float64(size) / float64(totalSize)) * 100.0,
 			Color:      colorMapping[language],
 		})

--- a/stats/service_test.go
+++ b/stats/service_test.go
@@ -141,10 +141,12 @@ func TestGetTopLanguages(t *testing.T) {
 	// Go should be the top language.
 	assert.Equal(t, "Go", result[0].Name)
 	assert.Equal(t, 28.372818839551712, result[0].Percentage)
+	assert.Equal(t, 2000, result[0].Size)
 
 	// Composite alias C/C++ should be the least used.
 	assert.Equal(t, "C/C++", result[6].Name)
 	assert.Equal(t, 1.4186409419775856, result[6].Percentage)
+	assert.Equal(t, 100, result[6].Size)
 
 	// Languages with identical share should have identical percentage.
 	// Use Java & Kotlin as examples.


### PR DESCRIPTION
Percentage is always relative to the other languages. Therefore, changing percentage alone does not actually tell if language usage has increased or decreased.

Add absolute byte size to response aswell, should one b inclined to compare sizes instead of shares.

Closes #14